### PR TITLE
[PF-607] feat: cleanup of restore CloudSQL instance

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -21,11 +21,11 @@ type BackupOptions struct {
 var backupOpts = &BackupOptions{}
 
 var backupCmd = &cobra.Command{
-	Use:   "backup",
+	Use:     "backup",
 	Example: "cloudsql-exporter backup --bucket=database-backup-bucket --project=f**********g --instance=db-instance-to-backup --ensure-iam-bindings-temp   --compression --user ******** --stats --password ${CLOUDSQL_PASSWORD}",
-	Short: "This export data from Cloud SQL instance to a GCS bucket.",
-	Long:  `This export data from Cloud SQL instance to a GCS bucket.`,
-	RunE:  execute,
+	Short:   "This export data from Cloud SQL instance to a GCS bucket.",
+	Long:    `This export data from Cloud SQL instance to a GCS bucket.`,
+	RunE:    execute,
 }
 
 func init() {

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -9,22 +9,27 @@ import (
 )
 
 type RestoreOptions struct {
-	File string
+	File        string
+	Cleanup     bool
+	StoreSecret bool
 }
 
 var restoreOpts = &RestoreOptions{}
 
 var restoreCmd = &cobra.Command{
-	Use:   "restore",
+	Use:     "restore",
 	Example: "cloudsql-exporter restore --bucket=database-backup-bucket --project=f**********g --instance=db-instance-to-backup  --user ******** --file gs://database-backup-bucket/db-instance-to-backup/cloudsql/dbname-20240422T173358.sql.gz",
-	Short: "This import data from a GCS bucket to Cloud SQL instance.",
-	Long:  `This import data from a GCS bucket to Cloud SQL instance.`,
-	RunE:  execute,
+	Short:   "This import data from a GCS bucket to Cloud SQL instance.",
+	Long:    `This import data from a GCS bucket to Cloud SQL instance.`,
+	RunE:    execute,
 }
 
 func init() {
 	cmd.RootCmd.AddCommand(restoreCmd)
 	cmd.AddRequiredFlag(restoreCmd, &restoreOpts.File, "file", "The full location of the file to restore cloudsql instance from. (required)")
+
+	restoreCmd.Flags().BoolVar(&restoreOpts.Cleanup, "cleanup", false, "Remove the CloudSQL restore instance after the restore integrity check passes. (default false)")
+	restoreCmd.Flags().BoolVar(&restoreOpts.StoreSecret, "store-password", true, "Store the password for the restore CloudSQL instance root user in the GCP Secret Manager (RESTORE-{INSTANCE_NAME}). (default true)")
 }
 
 func execute(ccmd *cobra.Command, args []string) error {
@@ -34,11 +39,13 @@ func execute(ccmd *cobra.Command, args []string) error {
 	user := GetString(ccmd, "user")
 
 	opts := &cloudsql.RestoreOptions{
-		Bucket:   bucket,
-		Project:  project,
-		Instance: instance,
-		File:     restoreOpts.File,
-		User:     user,
+		Bucket:      bucket,
+		Project:     project,
+		Instance:    instance,
+		User:        user,
+		File:        restoreOpts.File,
+		Cleanup:     restoreOpts.Cleanup,
+		StoreSecret: restoreOpts.StoreSecret,
 	}
 
 	_, err := restore.Restore(opts)

--- a/pkg/storage/bucket_test.go
+++ b/pkg/storage/bucket_test.go
@@ -81,14 +81,13 @@ func TestUserLocation(t *testing.T) {
 
 func TestStatsLocation(t *testing.T) {
 	loc := Location{
-		Bucket:   "flink-backup-bucket-flink-platform-staging",
-		Path:     "pricing/cloudsql/",
-		Time:     "20240404T152957",
+		Bucket: "flink-backup-bucket-flink-platform-staging",
+		Path:   "pricing/cloudsql/",
+		Time:   "20240404T152957",
 	}
 
 	assert.Equal(t, "pricing/cloudsql/stats-pricing-20240404T152957.yaml", loc.StatsLocation("pricing"))
 }
-
 
 func TestDatabaseLocation(t *testing.T) {
 	loc := Location{


### PR DESCRIPTION
Add the cleanup flag that will ensure that the restore CloudSQL instance is removed after the restore process passes the integrity check.

[PF-607](https://goflink.atlassian.net/browse/PF-607)
