### PR TITLE
[PF-1] chore: update to go 1.22 version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func AddRequiredPersistentFlagShort(ccmd *cobra.Command, name, shorthand, usage string) {
+	ccmd.PersistentFlags().StringP(name, shorthand, "", usage)
+	err := ccmd.MarkPersistentFlagRequired(name)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func AddRequiredFlag(ccmd *cobra.Command, ref *string, name, usage string) {
+	ccmd.Flags().StringVar(ref, name, "", usage)
+	err := ccmd.MarkFlagRequired(name)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func GetString(ccmd *cobra.Command, name string) string {
+	str, err := ccmd.Flags().GetString(name)
+	if err != nil {
+		panic(err)
+	}
+	return str
+}
+
+func GetBool(ccmd *cobra.Command, name string) bool {
+	b, err := ccmd.Flags().GetBool(name)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/fr12k/cloudsql-exporter
 
 go 1.22
 
-toolchain go1.22.1
-
 require (
 	cloud.google.com/go/iam v1.1.7
 	cloud.google.com/go/secretmanager v1.12.0
@@ -58,7 +56,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
-	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
+	github.com/googleapis/gax-go/v2 v2.12.3
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.25.0 // indirect
@@ -70,6 +68,6 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
-	google.golang.org/grpc v1.63.0 // indirect
+	google.golang.org/grpc v1.63.0
 	google.golang.org/protobuf v1.33.0 // indirect
 )


### PR DESCRIPTION
Update the Github workflows to use go version `1.22`.